### PR TITLE
Added the Text, Array, and Date Twig Extensions

### DIFF
--- a/TwigExtensions.module
+++ b/TwigExtensions.module
@@ -63,6 +63,9 @@ class TwigExtensions extends WireData implements Module {
     $this->twig = $event->arguments('twig');
 
     $this->addDebugExtension();
+    $this->addTextExtension();
+    $this->addArrayExtension();
+    $this->addDateExtension();
     $this->addIntlExtension();
   }
 
@@ -78,6 +81,54 @@ class TwigExtensions extends WireData implements Module {
   private function addDebugExtension() {
     if ($this->debug === 1 && $this->config->debug) {
       $this->twig->addExtension(new \Twig_Extension_Debug());
+    }
+  }
+
+  /*
+   * Add Text Extension
+   *
+   * Adds the truncate and wordwrap filters
+   *
+   */
+  private function addTextExtension() {
+    if ($this->textExt === 1) {
+      if (!class_exists('Twig_Extensions_Extension_Text')) {
+        require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');
+      }
+
+      $this->twig->addExtension(new \Twig_Extensions_Extension_Text());
+    }
+  }
+
+  /*
+   * Add Array Extension
+   *
+   * Adds the shuffle filter
+   *
+   */
+  private function addArrayExtension() {
+    if ($this->textExt === 1) {
+      if (!class_exists('Twig_Extensions_Extension_Array')) {
+        require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');
+      }
+
+      $this->twig->addExtension(new \Twig_Extensions_Extension_Array());
+    }
+  }
+
+  /*
+   * Add Date Extension
+   *
+   * Adds the time_diff filter
+   *
+   */
+  private function addDateExtension() {
+    if ($this->textExt === 1) {
+      if (!class_exists('Twig_Extensions_Extension_Date')) {
+        require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');
+      }
+
+      $this->twig->addExtension(new \Twig_Extensions_Extension_Date());
     }
   }
 

--- a/TwigExtensionsConfig.php
+++ b/TwigExtensionsConfig.php
@@ -11,6 +11,9 @@ class TwigExtensionsConfig extends ModuleConfig {
   public function getDefaults() {
     return array(
       'debug' => 1,
+      'textExt' => 1,
+      'arrayExt' => 1,
+      'dateExt' => 1,
       'intl' => 0
     );
   }
@@ -24,14 +27,14 @@ class TwigExtensionsConfig extends ModuleConfig {
   public function getInputfields() {
     // get submitted data
     $data = array();
-    foreach (array('debug', 'intl') as $ext) {
+    foreach (array('debug', 'textExt', 'arrayExt', 'dateExt', 'intl') as $ext) {
       $data[$ext] = isset($this->data[$ext]) ? $this->data[$ext] : false;
     }
 
     // get inputfields
     $inputfields = parent::getInputfields();
 
-    // debug
+    // Debug Extension checkbox
     $field = $this->modules->get('InputfieldCheckbox');
     $field->label = __('Enable the Debug Extension');
     $field->attr('name', 'debug');
@@ -40,7 +43,34 @@ class TwigExtensionsConfig extends ModuleConfig {
     $field->columnWidth = 50;
     $inputfields->add($field);
 
-    // intl
+    // Text Extension checkbox
+    $field = $this->modules->get('InputfieldCheckbox');
+    $field->label = __('Enable the Text Extension');
+    $field->attr('name', 'textExt');
+    $field->attr('value', 1);
+    $field->attr('checked', $data['textExt'] === 1 ? 'checked' : '' );
+    $field->columnWidth = 50;
+    $inputfields->add($field);
+
+    // Array Extension checkbox
+    $field = $this->modules->get('InputfieldCheckbox');
+    $field->label = __('Enable the Array Extension');
+    $field->attr('name', 'arrayExt');
+    $field->attr('value', 1);
+    $field->attr('checked', $data['arrayExt'] === 1 ? 'checked' : '' );
+    $field->columnWidth = 50;
+    $inputfields->add($field);
+
+    // Date Extension checkbox
+    $field = $this->modules->get('InputfieldCheckbox');
+    $field->label = __('Enable the Date Extension');
+    $field->attr('name', 'dateExt');
+    $field->attr('value', 1);
+    $field->attr('checked', $data['dateExt'] === 1 ? 'checked' : '' );
+    $field->columnWidth = 50;
+    $inputfields->add($field);
+
+    // Intl Extension checkbox
     $field = $this->modules->get('InputfieldCheckbox');
     $field->label = __('Enable the Intl Extension');
     $field->attr('name', 'intl');


### PR DESCRIPTION
This should fix https://github.com/justb3a/processwire-twigextensions/issues/2

Note: I left out the i18n extension because I'm not sure whether that will work or not.  I'm not familiar enough with Processwire's multilingual capabilities. 

Another thing we could do is reduce the multiple calls to:
`require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');`

Into one call at the top of the module
`require_once(/*NoCompile*/__DIR__ . '/vendor/autoload.php');`

Notice the NoCompile php comment?  That would prevent Processwire's file compiler from touching the included third party libraries.

Hope that helps