### PR TITLE
Module Fixes for variable names and updated documentation links in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,36 @@ Allows customizing twig, e.g. add extensions.
 
 After installation go to module settings and enable/disable the required extensions/functions.
 
+**Includes:**
+Twig Extensions Repository https://github.com/twigphp/Twig-extensions
+
 **Usage:**
 
 Adds the following extensions/functions:
 
-* [Debug](http://twig.sensiolabs.org/doc/functions/dump.html) // only if debug mode is turned on
+* [Debug](twig.sensiolabs.org/doc/functions/dump.html) // only if debug mode is turned on
 
     ```twig
     {{ dump(page) }}
     ```
 
-* [Intl](http://twig.sensiolabs.org/doc/extensions/intl.html)
+* [Intl](http://twig-extensions.readthedocs.io/en/latest/intl.html)
 
     ```twig
     {{ post.published|localizeddate('medium', 'none', locale) }}
+    ```
+* [Text](http://twig-extensions.readthedocs.io/en/latest/text.html)
+
+    ```twig
+    {{ "Hello World!"|truncate(5) }}
+    ```
+* [Array](http://twig-extensions.readthedocs.io/en/latest/array.html)
+
+    ```twig
+    {{ post.published|shuffle }}
+    ```
+* [Date](http://twig-extensions.readthedocs.io/en/latest/date.html)
+
+    ```twig
+    {{ post.published|date("M jS, Y") }}
     ```

--- a/TwigExtensions.module
+++ b/TwigExtensions.module
@@ -93,7 +93,7 @@ class TwigExtensions extends WireData implements Module {
   private function addTextExtension() {
     if ($this->textExt === 1) {
       if (!class_exists('Twig_Extensions_Extension_Text')) {
-        require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');
+        require(/*NoCompile*/__DIR__ . '/vendor/autoload.php');
       }
 
       $this->twig->addExtension(new \Twig_Extensions_Extension_Text());
@@ -107,9 +107,9 @@ class TwigExtensions extends WireData implements Module {
    *
    */
   private function addArrayExtension() {
-    if ($this->textExt === 1) {
+    if ($this->arrayExt === 1) {
       if (!class_exists('Twig_Extensions_Extension_Array')) {
-        require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');
+        require(/*NoCompile*/__DIR__ . '/vendor/autoload.php');
       }
 
       $this->twig->addExtension(new \Twig_Extensions_Extension_Array());
@@ -123,9 +123,9 @@ class TwigExtensions extends WireData implements Module {
    *
    */
   private function addDateExtension() {
-    if ($this->textExt === 1) {
+    if ($this->dateExt === 1) {
       if (!class_exists('Twig_Extensions_Extension_Date')) {
-        require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');
+        require(/*NoCompile*/__DIR__ . '/vendor/autoload.php');
       }
 
       $this->twig->addExtension(new \Twig_Extensions_Extension_Date());
@@ -145,7 +145,7 @@ class TwigExtensions extends WireData implements Module {
   private function addIntlExtension() {
     if ($this->intl === 1) {
       if (!class_exists('Twig_Extensions_Extension_Intl')) {
-        require(wire('config')->paths->TwigExtensions . 'vendor/autoload.php');
+        require(/*NoCompile*/__DIR__ . '/vendor/autoload.php');
       }
 
       $this->twig->addExtension(new \Twig_Extensions_Extension_Intl());

--- a/TwigExtensions.module
+++ b/TwigExtensions.module
@@ -119,7 +119,7 @@ class TwigExtensions extends WireData implements Module {
   /*
    * Add Date Extension
    *
-   * Adds the time_diff filter
+   * Adds the date and time_diff filter
    *
    */
   private function addDateExtension() {


### PR DESCRIPTION
Hi @justb3a,

I started using this module on another site and found some bugs:
1. The variable names were wrong causing it to not work (my fault)
2. The third party extensions were being compiled with Processwire's file compiler
3. The documentation links in the readme.md were broken

All this should be fixed with this pull request.

Hope that helps