### PR TITLE
Check if twig extensions are already autoloaded

### DIFF
--- a/TwigExtensions.module
+++ b/TwigExtensions.module
@@ -70,7 +70,9 @@ class TwigExtensions extends WireData implements Module {
     }
 
     if ($enabledExtensions) {
-      require(/*NoCompile*/__DIR__ . '/vendor/autoload.php');
+      if (!class_exists('Twig_Extensions_Autoloader')) {
+        require(/*NoCompile*/__DIR__ . '/vendor/autoload.php');
+      }
 
       foreach ($enabledExtensions as $ext) {
         $addExtension = 'add' . ucfirst($ext);


### PR DESCRIPTION
Could happen that certain times Twig Extensions are already loaded for current project, so better if they are loaded only if needed.