### PR TITLE
Removed the debug extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ Adds the following extensions/helpers:
 
 ## Extensions
 
-* [Debug][dump] // only if debug mode is turned on
-
-    ```twig
-    {# dump - dumps information about a template variable #}
-    {{ dump('Hello World!') }}
-    string(12) "Hello World!"
-    ```
 * [Intl][intl]
 
     ```twig
@@ -101,7 +94,6 @@ Adds the following extensions/helpers:
 [tef]:      http://modules.processwire.com/modules/template-engine-factory/ 'TemplateEngineFactory'
 [tet]:      http://modules.processwire.com/modules/template-engine-twig/    'TemplateEngineTwig' 
 [twigrepo]: https://github.com/twigphp/Twig-extensions                      'Twig Extension Repository'
-[dump]:     http://twig.sensiolabs.org/doc/2.x/functions/dump.html          'Dump Extension'
 [intl]:     http://twig-extensions.readthedocs.io/en/latest/intl.html       'Intl Extension'
 [text]:     http://twig-extensions.readthedocs.io/en/latest/text.html       'Text Extension'
 [array]:    http://twig-extensions.readthedocs.io/en/latest/array.html      'Array Extension'

--- a/TwigExtensions.module
+++ b/TwigExtensions.module
@@ -87,22 +87,6 @@ class TwigExtensions extends WireData implements Module {
   }
 
   /*
-   * Add Debug Extension
-   *
-   * The dump function dumps information about a template variable.
-   * This is mostly useful to debug a template that does not behave
-   * as expected by introspecting its variables
-   *
-   * Usage: {{ dump(page) }}
-   */
-  private function addDebugExt() {
-    // always add this extension if it's enabled
-    // if `config->debug` is set to false, it's just omitted
-    // otherwise it would throw an exception
-    $this->twig->addExtension(new \Twig_Extension_Debug());
-  }
-
-  /*
    * Add Text Extension
    * Adds the truncate and wordwrap filters
    */

--- a/TwigExtensionsConfig.php
+++ b/TwigExtensionsConfig.php
@@ -10,7 +10,6 @@ class TwigExtensionsConfig extends ModuleConfig {
    */
   public function getDefaults() {
     return array(
-      'debugExt' => 1,
       'textExt' => 0,
       'arrayExt' => 0,
       'dateExt' => 0,
@@ -34,14 +33,6 @@ class TwigExtensionsConfig extends ModuleConfig {
     // ----------
     $fieldset = $this->modules->get('InputfieldFieldset');
     $fieldset->label = __('EXTENSIONS');
-
-    // Debug Extension checkbox
-    $field = $this->modules->get('InputfieldCheckbox');
-    $field->label = __('Enable the Debug Extension');
-    $field->attr('name', 'debugExt');
-    $field->attr('value', 1);
-    $field->columnWidth = 33;
-    $fieldset->add($field);
 
     // Text Extension checkbox
     $field = $this->modules->get('InputfieldCheckbox');


### PR DESCRIPTION
The debug extension is included in TemplateEngineTwig now.  See https://github.com/wanze/TemplateEngineTwig/commit/776d3d8b3cf2fd04ea584d92fdc33e214468996b#diff-174a5e0bac30f021aa66bb8899550f87R55